### PR TITLE
Fix bug for Word.is_kana, build full freq_map for expressions

### DIFF
--- a/src/segmentation/tokenizer.rs
+++ b/src/segmentation/tokenizer.rs
@@ -209,7 +209,12 @@ pub fn extract_words(
                             .unwrap_or(0);
 
                         phrase.sentence_references.push((ord, index_in_sentence));
-                        phrase.frequencies.insert("HARMONIC".to_string(), frequency);
+                        let freq_map = frequency_manager.build_freq_map(
+                            &phrase.lemma_form,
+                            &phrase.lemma_reading,
+                            phrase.is_kana,
+                        );
+                        phrase.frequencies = freq_map;
                         sentence_terms.push(phrase);
 
                         break 'outer; // Stop on the largest phrase that satisfies the heuristic

--- a/src/segmentation/word.rs
+++ b/src/segmentation/word.rs
@@ -150,13 +150,14 @@ pub struct Word {
 impl From<Word> for Term {
     fn from(word: Word) -> Term {
         if let Some(main_word) = word.main_word {
+            let is_kana = main_word.surface.as_str().is_kana();
             Term {
                 id: 0,
                 lemma_form: main_word.lemma_form,
                 lemma_reading: main_word.lemma_hatsuon,
                 surface_form: main_word.surface,
                 surface_reading: main_word.surface_hatsuon.clone(),
-                is_kana: main_word.surface_hatsuon.as_str().is_kana(),
+                is_kana,
                 part_of_speech: word.part_of_speech,
                 full_segment: word.surface_form,
                 full_segment_reading: word.surface_hatsuon,
@@ -164,13 +165,14 @@ impl From<Word> for Term {
                 sentence_references: Vec::new(),
             }
         } else {
+            let is_kana = word.surface_form.as_str().is_kana();
             Term {
                 id: 0,
                 lemma_form: word.lemma_form,
                 lemma_reading: word.lemma_hatsuon,
                 surface_form: word.surface_form.clone(),
                 surface_reading: word.surface_hatsuon.clone(),
-                is_kana: word.surface_hatsuon.as_str().is_kana(),
+                is_kana,
                 part_of_speech: word.part_of_speech,
                 full_segment: word.surface_form,
                 full_segment_reading: word.surface_hatsuon,


### PR DESCRIPTION


- Should be a huge improvement on frequency fetching. Before, due to a bug, we were assuming all terms were in their kana form and getting the kana only frequency instead of the kanji frequency.