### PR TITLE
fix: make the setup banner readable and stop the bulk bar hiding rows

### DIFF
--- a/src-tauri/ui/src/lib/components/FrequencyWeightsModal.svelte
+++ b/src-tauri/ui/src/lib/components/FrequencyWeightsModal.svelte
@@ -473,9 +473,9 @@
 		opacity: 1;
 	}
 	.del .danger {
-		padding: 0.15rem 0.4rem;
+		padding: 0.3rem 0.5rem;
 		font-size: 0.75rem;
-		color: #fff;
+		color: var(--bg);
 		background: var(--danger);
 		border: none;
 		border-radius: 3px;

--- a/src-tauri/ui/src/lib/components/SetupBanner.svelte
+++ b/src-tauri/ui/src/lib/components/SetupBanner.svelte
@@ -15,13 +15,13 @@
 		padding: 0.35rem 1rem;
 		border: none;
 		border-radius: 0;
-		background: color-mix(in srgb, var(--warning) 55%, var(--bg));
-		color: var(--text);
+		background: var(--warning);
+		color: var(--bg);
 		font-size: 0.875rem;
 		text-align: center;
 		cursor: pointer;
 	}
 	.banner:hover {
-		background: color-mix(in srgb, var(--warning) 70%, var(--bg));
+		background: color-mix(in srgb, var(--warning) 90%, var(--text));
 	}
 </style>

--- a/src-tauri/ui/src/routes/+page.svelte
+++ b/src-tauri/ui/src/routes/+page.svelte
@@ -22,6 +22,7 @@
 		ankiFilterActive,
 		refreshTerms,
 		refreshMinedState,
+		selectedTerms,
 		settings
 	} from '$lib/stores';
 	import TopBar from '$lib/components/TopBar.svelte';
@@ -151,7 +152,7 @@
 			<TableControls />
 			<!-- The one scroll region in the file view: title/coverage/controls above
 			     stay put, the sticky column header sticks to this container's top. -->
-			<div class="table-scroll">
+			<div class="table-scroll" class:bulk-open={$selectedTerms.size > 0}>
 				<TermTable terms={$visibleTerms} sentences={$fileResult.sentences} />
 			</div>
 		{:else}
@@ -322,6 +323,10 @@
 		flex: 1 1 auto;
 		min-height: 0;
 		overflow-y: auto;
+	}
+	/* Must clear `.bulk-bar` (TermTable), which is fixed and out of flow. */
+	.table-scroll.bulk-open {
+		padding-bottom: 3.5rem;
 	}
 	.landing {
 		display: flex;


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>