### PR TITLE
fix: cap viewport-sized overlays against the zoomed window

### DIFF
--- a/src-tauri/ui/src/lib/components/DefinitionPopover.svelte
+++ b/src-tauri/ui/src/lib/components/DefinitionPopover.svelte
@@ -358,8 +358,8 @@
 		overflow: hidden;
 		min-width: 14rem;
 		min-height: 4rem;
-		max-width: calc(100vw - 1rem);
-		max-height: calc(100vh - 1rem);
+		max-width: calc(100% - 1rem);
+		max-height: calc(100% - 1rem);
 	}
 	/* Scale the content, not .popover itself: the position math and remembered
 	 * size (script above) work in unscaled px. */

--- a/src-tauri/ui/src/lib/components/TermTable.svelte
+++ b/src-tauri/ui/src/lib/components/TermTable.svelte
@@ -1161,7 +1161,7 @@
 		display: flex;
 		align-items: center;
 		gap: 0.6rem;
-		max-width: 90vw;
+		max-width: 90%;
 		padding: 0.45rem 0.9rem;
 		background: var(--bg-panel);
 		border: 1px solid var(--border);

--- a/src-tauri/ui/src/routes/+page.svelte
+++ b/src-tauri/ui/src/routes/+page.svelte
@@ -438,7 +438,7 @@
 		display: flex;
 		align-items: center;
 		gap: 0.6rem;
-		max-width: 90vw;
+		max-width: 90%;
 		padding: 0.6rem 0.9rem;
 		background: var(--bg-raised);
 		border: 1px solid var(--danger);
@@ -457,7 +457,7 @@
 		top: 3.2rem;
 		left: 50%;
 		transform: translateX(-50%);
-		max-width: 80vw;
+		max-width: 80%;
 		padding: 0.45rem 0.9rem;
 		background: var(--bg-raised);
 		border: 1px solid var(--success);


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>