### PR TITLE
fix: give the two only-path icon buttons a 24px target

### DIFF
--- a/src-tauri/ui/src/lib/components/KnowledgeSummary.svelte
+++ b/src-tauri/ui/src/lib/components/KnowledgeSummary.svelte
@@ -99,6 +99,7 @@
 	}
 	.mode-title {
 		padding: 0;
+		min-height: 24px;
 		background: none;
 		border: none;
 		font-size: 14px;
@@ -108,6 +109,8 @@
 	}
 	.swap {
 		padding: 0;
+		min-width: 24px;
+		min-height: 24px;
 		background: none;
 		border: none;
 		font-size: 13px;

--- a/src-tauri/ui/src/routes/themes/+page.svelte
+++ b/src-tauri/ui/src/routes/themes/+page.svelte
@@ -195,6 +195,8 @@
 		top: 0.25rem;
 		right: 0.25rem;
 		padding: 0 0.3rem;
+		min-width: 24px;
+		min-height: 24px;
 		font-size: 0.75rem;
 		background: none;
 		border: none;


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>