### PR TITLE
fix: give the ignore list's icon buttons a 24px target

### DIFF
--- a/src-tauri/ui/src/lib/components/IgnoreListModal.svelte
+++ b/src-tauri/ui/src/lib/components/IgnoreListModal.svelte
@@ -319,6 +319,8 @@
 	}
 	.icon {
 		padding: 0 0.25rem;
+		min-width: 24px;
+		min-height: 24px;
 		background: none;
 		border: none;
 		color: var(--text);


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>