### PR TITLE
fix: label both tab states in the asbplayer picker

### DIFF
--- a/src-tauri/ui/src/lib/components/AsbplayerModal.svelte
+++ b/src-tauri/ui/src/lib/components/AsbplayerModal.svelte
@@ -101,7 +101,9 @@
 							>{m.title?.trim() || 'Untitled video'}</span
 						>
 						<span class="badge">{m.media_type}</span>
-						{#if m.active}<span class="badge active">active tab</span>{/if}
+						<span class="badge" class:active={m.active}
+							>{m.active ? 'active tab' : 'background tab'}</span
+						>
 						<button
 							class="load"
 							disabled={!hasSubs || busyId !== null}


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>